### PR TITLE
allow custom next_previous_post_link function in child theme

### DIFF
--- a/library/structure/content-extensions.php
+++ b/library/structure/content-extensions.php
@@ -758,6 +758,8 @@ function travelify_next_previous() {
 /****************************************************************************************/
 
 add_action( 'travelify_after_post_content', 'travelify_next_previous_post_link', 10 );
+
+if ( ! function_exists( 'travelify_next_previous_post_link' ) ) :
 /**
  * Shows the next or previous posts link with respective names.
  */
@@ -781,6 +783,8 @@ function travelify_next_previous_post_link() {
 		}
 	}
 }
+
+endif;
 
 /****************************************************************************************/
 


### PR DESCRIPTION
Currently overriding travelify_next_previous_post_link fails. I'd like to customize it in a child theme, see https://colorlib.com/wp/forums/topic/navigation-next-e-prev-by-category/