### PR TITLE
allow custom next_previous_post_link function in child theme

### DIFF
--- a/library/structure/content-extensions.php
+++ b/library/structure/content-extensions.php
@@ -752,6 +752,8 @@ function travelify_next_previous() {
 /****************************************************************************************/
 
 add_action( 'travelify_after_post_content', 'travelify_next_previous_post_link', 10 );
+
+if ( ! function_exists( 'travelify_next_previous_post_link' ) ) :
 /**
  * Shows the next or previous posts link with respective names.
  */
@@ -775,6 +777,7 @@ function travelify_next_previous_post_link() {
 		}
 	}
 }
+endif;
 
 /****************************************************************************************/
 


### PR DESCRIPTION
This change has already been merged in #19 was however overwritten by @cristianraiber in #24